### PR TITLE
Distinguished V1 and V2 APIs in Swagger

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/config/SwaggerConfig.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/config/SwaggerConfig.java
@@ -34,26 +34,31 @@ public class SwaggerConfig {
                         )
                 );
     }
-    
+
     @Bean
     public GroupedOpenApi v1Api() {
         return GroupedOpenApi.builder()
-        		   .group("version 1")
+        		   .group("version1")
         		   .packagesToScan("uk.ac.ebi.spot.ols.controller.api.v1")
         		   .build();
     }
-    
+
     @Bean
     public GroupedOpenApi v2Api() {
         return GroupedOpenApi.builder()
-        		   .group("version 2")
-        		   .packagesToScan(
-        				   "uk.ac.ebi.spot.ols.controller.api.v2",
-        				   "uk.ac.ebi.spot.ols.reststatistics.controller"
-        			)
+        		   .group("version2")
+        		   .packagesToScan("uk.ac.ebi.spot.ols.controller.api.v2")
         		   .build();
     }
-    
+
+    @Bean
+    public GroupedOpenApi callStatisticsApi() {
+        return GroupedOpenApi.builder()
+                .group("call_statistics")
+                .packagesToScan("uk.ac.ebi.spot.ols.reststatistics.controller")
+                .build();
+    }
+
 
 }
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/config/SwaggerConfig.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/config/SwaggerConfig.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.servers.Server;
+
+import org.springdoc.core.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -32,6 +34,26 @@ public class SwaggerConfig {
                         )
                 );
     }
+    
+    @Bean
+    public GroupedOpenApi v1Api() {
+        return GroupedOpenApi.builder()
+        		   .group("version 1")
+        		   .packagesToScan("uk.ac.ebi.spot.ols.controller.api.v1")
+        		   .build();
+    }
+    
+    @Bean
+    public GroupedOpenApi v2Api() {
+        return GroupedOpenApi.builder()
+        		   .group("version 2")
+        		   .packagesToScan(
+        				   "uk.ac.ebi.spot.ols.controller.api.v2",
+        				   "uk.ac.ebi.spot.ols.reststatistics.controller"
+        			)
+        		   .build();
+    }
+    
 
 }
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologySKOSConceptController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologySKOSConceptController.java
@@ -42,7 +42,7 @@ import java.util.*;
  */
 @RestController
 @RequestMapping("/api/ontologies")
-@Tag(name = "v1-ontology-skos-controller", description = "SKOS concept hierarchies and relations extracted from individuals (instances) from a particular ontology in this service")
+@Tag(name = "Ontology SKOS Concept Controller", description = "SKOS concept hierarchies and relations extracted from individuals (instances) from a particular ontology in this service")
 public class V1OntologySKOSConceptController {
 
     private Logger log = LoggerFactory.getLogger(getClass());

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologySKOSConceptController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologySKOSConceptController.java
@@ -41,7 +41,7 @@ import java.util.*;
  */
 @RestController
 @RequestMapping("/api/v2/ontologies")
-@Tag(name = "v2-ontology-skos-controller", description = "SKOS concept hierarchies and relations extracted from individuals (instances) from a particular ontology in this service")
+@Tag(name = "V2 Ontology SKOS Concept Controller", description = "SKOS concept hierarchies and relations extracted from individuals (instances) from a particular ontology in this service")
 public class V2OntologySKOSConceptController {
 
     @Autowired

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.jackson.serialization.INDENT_OUTPUT=true
 springdoc.swagger-ui.path=/swagger-ui-ols4.html
 springdoc.swagger-ui.operationsSorter=method
 springdoc.swagger-ui.disable-swagger-default-url=true
-
+springdoc.swagger-ui.urlsPrimaryName=version2
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.web.resources.add-mappings=false
 


### PR DESCRIPTION
Fixes #125 

1. Added versioning dropdown to swagger-ui by grouping APIs
2. By default v1APIs are shown

Users can switch between version by selecting appropriate dropdown in swagger-ui

![image](https://github.com/user-attachments/assets/742825ef-0621-4503-870d-8694a92b09b1)
