### PR TITLE
Fixed entities count by considering only unique URIs.

### DIFF
--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/OntologyGraph.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/OntologyGraph.java
@@ -45,6 +45,8 @@ public class OntologyGraph implements StreamRDF {
     public int numberOfClasses = 0;
     public int numberOfProperties = 0;
     public int numberOfIndividuals = 0;
+    
+    public Set<String> entities = new HashSet<String>();
 
     private static final Logger logger = LoggerFactory.getLogger(OntologyGraph.class);
 
@@ -773,7 +775,7 @@ public class OntologyGraph implements StreamRDF {
             case "http://www.w3.org/2000/01/rdf-schema#Class":
             case "http://www.w3.org/2004/02/skos/core#Concept":
                 subjNode.types.add(OntologyNode.NodeType.CLASS);
-                if(subjNode.uri != null) {
+                if(subjNode.uri != null && entities.add(subjNode.uri)) {
                     ++ numberOfClasses;
                 }
 
@@ -799,7 +801,7 @@ public class OntologyGraph implements StreamRDF {
             case "http://www.w3.org/2002/07/owl#NamedIndividual":
                 subjNode.types.add(OntologyNode.NodeType.INDIVIDUAL);
 
-                if(subjNode.uri != null) {
+                if(subjNode.uri != null && entities.add(subjNode.uri)) {
                     ++ numberOfIndividuals;
                 }
 
@@ -835,7 +837,7 @@ public class OntologyGraph implements StreamRDF {
     private void addAddAndCountProperties(OntologyNode subjNode) {
         subjNode.types.add(OntologyNode.NodeType.PROPERTY);
 
-        if (subjNode.uri != null) {
+        if (subjNode.uri != null && entities.add(subjNode.uri)) {
             ++numberOfProperties;
         }
     }


### PR DESCRIPTION
Fixes #119 

Problem:
1. Few URIs are processed more than once while parsing which resulted in increased count

Fix:
1. Added URIs to set and counted only the unique URI

 For the ontology sosa - https://api.terminology.tib.eu/api/v2/ontologies/sosa

**Before the fix**
![image](https://github.com/user-attachments/assets/7c4d9dc6-511b-4baf-a80d-91b4fb8f5930)

**After the fix**
![image](https://github.com/user-attachments/assets/aa222340-e62e-4ded-bcef-3753739cf3d9)
