### PR TITLE
Exclude self node in hierarchical children

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/neo4j/OlsNeo4jClient.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/neo4j/OlsNeo4jClient.java
@@ -107,11 +107,15 @@ public class OlsNeo4jClient {
 		String query =
 		  "MATCH (a:" + type + ")<-[edge:" + edge + "]-(b) "
 		+ "WHERE a.id = $id "
+		+ "AND "
+		+ "a.id <> b.id "
 		+ "RETURN distinct b";
 
 		String countQuery =
 		  "MATCH (a:" + type + ")<-[edge:" + edge + "]-(b) "
 		+ "WHERE a.id = $id "
+		+ "AND "
+		+ "a.id <> b.id "
 		+ "RETURN count(distinct b)";
 
 		return neo4jClient.queryPaginated(query, "b", countQuery, parameters("type", type, "id", id), pageable);

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DirectParentsAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DirectParentsAnnotator.java
@@ -24,7 +24,7 @@ public class DirectParentsAnnotator {
             // skip bnodes
             if(c.uri == null)
                 continue;
-
+            
             if (c.types.contains(OntologyNode.NodeType.CLASS)) {
 
                 List<PropertyValue> parents = c.properties.getPropertyValues("http://www.w3.org/2000/01/rdf-schema#subClassOf");
@@ -32,7 +32,8 @@ public class DirectParentsAnnotator {
 
                 if(parents != null) {
                     for(PropertyValue parent : parents) {
-                        if(parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())) {
+                        if(parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())
+                        		&& !c.uri.equalsIgnoreCase(((PropertyValueURI) parent).getUri())) {
                             directParents.add((PropertyValueURI) parent);
                         }
                     }

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/HierarchicalParentsAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/HierarchicalParentsAnnotator.java
@@ -52,8 +52,9 @@ public class HierarchicalParentsAnnotator {
 
                 if(parents != null) {
                     for(PropertyValue parent : parents) {
-
-                        if (parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())) {
+                    	
+                        if (parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())
+                        		&& !c.uri.equalsIgnoreCase(((PropertyValueURI) parent).getUri())) {
 
                             // Direct parent; these are also considered hierarchical parents
                             hierarchicalParents.add((PropertyValueURI) parent);


### PR DESCRIPTION
Fixes #133 

**Solution**
1. Updated Neo4j query to exclude the self node while fetching hierarchical children

**Before the Fix**
![image](https://github.com/user-attachments/assets/1345b9ba-156c-4342-80d4-65e3841b04ce)


**After the fix**
![image](https://github.com/user-attachments/assets/3f096b12-2df3-4aaf-bd1c-f4163eef0e4d)


