### PR TITLE
141 ontology ingestion failure due to url redirection

### DIFF
--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/OntologyConversion.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/OntologyConversion.java
@@ -93,6 +93,7 @@ public class OntologyConversion {
 
     private OWLOntology loadOntology(String url) throws IOException {
         OWLOntologyManager ontManager = OWLManager.createOWLOntologyManager();
+        ontManager.getIRIMappers().add(new RedirectingIRIMapper());
         OWLOntology ont;
         InputStream is = null;
         URLConnection con = null;

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/RedirectResolver.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/RedirectResolver.java
@@ -1,0 +1,53 @@
+package uk.ac.ebi.rdf2json;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ *@author Deepan Anbalagan
+ *@email deepan.anbalagan@tib.eu
+ *TIB-Leibniz Information Center for Science and Technology
+*/
+public class RedirectResolver {
+	
+	private static final Map<String, String> redirectMap = new HashMap<>();
+    
+	//This will be removed after the solution is finalized
+    /*static {
+        // Add known redirects here
+        redirectMap.put("http://www.opengis.net/ont/sf",
+                        "https://opengeospatial.github.io/ogc-geosparql/geosparql11/sf_geometries.ttl");
+        redirectMap.put("http://www.opengis.net/ont/geosparql",
+                "https://opengeospatial.github.io/ogc-geosparql/geosparql11/geo.ttl");
+    }*/
+    
+   static {
+        Properties properties = new Properties();
+
+        try (InputStream inputStream = RedirectResolver.class.getClassLoader()
+                                                   .getResourceAsStream("redirect.properties")) {
+            if (inputStream == null) {
+                throw new RuntimeException("config.properties not found in classpath");
+            }
+
+            properties.load(inputStream);
+
+            for (String key : properties.stringPropertyNames()) {
+            	redirectMap.put(key, properties.getProperty(key));
+            }
+
+            System.out.println("Properties loaded: " + redirectMap);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static String resolve(String iri) {
+        return redirectMap.getOrDefault(iri, iri);
+    }
+
+}

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/RedirectingIRIMapper.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/RedirectingIRIMapper.java
@@ -1,0 +1,17 @@
+package uk.ac.ebi.rdf2json;
+
+import org.semanticweb.owlapi.model.*;
+
+/**
+ *@author Deepan Anbalagan
+ *@email deepan.anbalagan@tib.eu
+ *TIB-Leibniz Information Center for Science and Technology
+*/
+public class RedirectingIRIMapper implements OWLOntologyIRIMapper {
+	
+    @Override
+    public IRI getDocumentIRI(IRI ontologyIRI) {
+        return IRI.create(RedirectResolver.resolve(ontologyIRI.toString()));
+    }
+
+}

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DirectParentsAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DirectParentsAnnotator.java
@@ -33,6 +33,7 @@ public class DirectParentsAnnotator {
                 if(parents != null) {
                     for(PropertyValue parent : parents) {
                         if(parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())) {
+                        	
                         	directParents.add((PropertyValueURI) parent);
                         }
                     }

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DirectParentsAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DirectParentsAnnotator.java
@@ -33,8 +33,7 @@ public class DirectParentsAnnotator {
                 if(parents != null) {
                     for(PropertyValue parent : parents) {
                         if(parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())) {
-                        	if(!((PropertyValueURI) parent).getUri().equalsIgnoreCase(id))
-                        		directParents.add((PropertyValueURI) parent);
+                        	directParents.add((PropertyValueURI) parent);
                         }
                     }
                 }

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DirectParentsAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DirectParentsAnnotator.java
@@ -33,7 +33,8 @@ public class DirectParentsAnnotator {
                 if(parents != null) {
                     for(PropertyValue parent : parents) {
                         if(parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())) {
-                            directParents.add((PropertyValueURI) parent);
+                        	if(!((PropertyValueURI) parent).getUri().equalsIgnoreCase(id))
+                        		directParents.add((PropertyValueURI) parent);
                         }
                     }
                 }

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/HierarchicalParentsAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/HierarchicalParentsAnnotator.java
@@ -56,7 +56,8 @@ public class HierarchicalParentsAnnotator {
                         if (parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())) {
 
                             // Direct parent; these are also considered hierarchical parents
-                            hierarchicalParents.add((PropertyValueURI) parent);
+                        	if(!((PropertyValueURI) parent).getUri().equalsIgnoreCase(id))
+                        		hierarchicalParents.add((PropertyValueURI) parent);
                         }
                     }
                 }

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/HierarchicalParentsAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/HierarchicalParentsAnnotator.java
@@ -56,8 +56,7 @@ public class HierarchicalParentsAnnotator {
                         if (parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())) {
 
                             // Direct parent; these are also considered hierarchical parents
-                        	if(!((PropertyValueURI) parent).getUri().equalsIgnoreCase(id))
-                        		hierarchicalParents.add((PropertyValueURI) parent);
+                        	hierarchicalParents.add((PropertyValueURI) parent);
                         }
                     }
                 }

--- a/dataload/rdf2json/src/main/resources/redirect.properties
+++ b/dataload/rdf2json/src/main/resources/redirect.properties
@@ -1,0 +1,2 @@
+http\://www.opengis.net/ont/sf=https://opengeospatial.github.io/ogc-geosparql/geosparql11/sf_geometries.ttl
+http\://www.opengis.net/ont/geosparql=https://opengeospatial.github.io/ogc-geosparql/geosparql11/geo.ttl


### PR DESCRIPTION
Fixes #141

1. Created "IRI mapper" which will be used during ontology parsing.
2. Iri Mapper has data read from "redirect.properties"

"redirect.properties" - has original url and the redirected url which will be stored as Key and value in IriMapper

During ontology parsing, when the originalUrl is detected, it uses IriMapper to get the redirected url, which solves the redirection issue.

