### PR TITLE
Exclude self node in hierarchical children

### DIFF
--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DirectParentsAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DirectParentsAnnotator.java
@@ -32,7 +32,8 @@ public class DirectParentsAnnotator {
 
                 if(parents != null) {
                     for(PropertyValue parent : parents) {
-                        if(parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())) {
+                    	if(parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())
+                        		&& !c.uri.equalsIgnoreCase(((PropertyValueURI) parent).getUri())) {
                             directParents.add((PropertyValueURI) parent);
                         }
                     }

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/HierarchicalParentsAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/HierarchicalParentsAnnotator.java
@@ -53,7 +53,8 @@ public class HierarchicalParentsAnnotator {
                 if(parents != null) {
                     for(PropertyValue parent : parents) {
 
-                        if (parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())) {
+                    	if (parent.getType() == PropertyValue.Type.URI && graph.nodes.containsKey(((PropertyValueURI) parent).getUri())
+                        		&& !c.uri.equalsIgnoreCase(((PropertyValueURI) parent).getUri())) {
 
                             // Direct parent; these are also considered hierarchical parents
                             hierarchicalParents.add((PropertyValueURI) parent);


### PR DESCRIPTION
Fixes https://github.com/TIBHannover/ols4/issues/133

Solution

The issue is fixed at the conversion level. Now Neo4j won't have the self referenced direct or Hierarchical parent

Before the Fix
<img width="810" height="324" alt="image" src="https://github.com/user-attachments/assets/0c143e4d-3f67-4dc4-9616-76f33319c5b5" />


After the fix
<img width="656" height="156" alt="image" src="https://github.com/user-attachments/assets/8ff752c3-3440-45ac-b368-849957c2ed0f" />
