### PR TITLE
141 ontology ingestion failure due to url redirection 1

### DIFF
--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/OntologyConversion.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/OntologyConversion.java
@@ -9,12 +9,12 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLConnection;
+import java.net.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 
 /**
  * @author Erhun Giray TUNCAY
@@ -96,6 +96,8 @@ public class OntologyConversion {
         OWLOntology ont;
         InputStream is = null;
         URLConnection con = null;
+        String originalUrl = url;
+
         try {
             try {
                 URL tempURL = new URL(url);
@@ -122,12 +124,81 @@ public class OntologyConversion {
                 }
             }
         } catch (OWLOntologyCreationException e) {
-            throw new RuntimeException(e);
+            ont = importsPrefixesAndNonUnicodeCharactersCorrectingLoader(originalUrl);
         } finally {
             if (is != null)
                 is.close();
         }
         return ont;
+    }
+
+    public static OWLOntology importsPrefixesAndNonUnicodeCharactersCorrectingLoader(String url) throws IOException {
+        url = urlConverter(url).toExternalForm();
+        OWLOntologyManager ontManager = OWLManager.createOWLOntologyManager();
+        OWLOntologyLoaderConfiguration config = new OWLOntologyLoaderConfiguration();
+        config = config.setMissingImportHandlingStrategy(MissingImportHandlingStrategy.SILENT);
+        ontManager.setOntologyLoaderConfiguration(config);
+        OWLOntology ontology;
+        try {
+            try {
+                IRI documentIRI = IRI.create(url);
+                ontology = ontManager.loadOntology(documentIRI);
+            } catch (Exception e) {
+                try (InputStream inputStream = urlConverter(url).openStream()) {
+                    String content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+                    content = content.replaceAll("[^\\u0009\\u000A\\u000D\\u0020-\\uFFFF]", "");
+                    Path cleanedPath = Files.writeString(Paths.get("ontology_cleaned.owl"), content, StandardCharsets.UTF_8);
+                    try (InputStream is = Files.newInputStream(cleanedPath)){
+                        ontology = ontManager.loadOntologyFromOntologyDocument(is);
+                    }
+                }
+            }
+
+            // The loaded ontology will contain the import declarations
+            OWLDataFactory df = ontManager.getOWLDataFactory();
+            for (OWLImportsDeclaration declaration : ontology.getImportsDeclarations()){
+                IRI modifiedIri = IRI.create(urlConverter(declaration.getIRI().toString()));
+                OWLImportsDeclaration modifiedDeclaration = df.getOWLImportsDeclaration(modifiedIri);
+                logger.info("original iri {} being replaced with {}", declaration.getIRI(), modifiedIri);
+                ontManager.applyChange(new RemoveImport(ontology, declaration));
+                ontManager.applyChange(new AddImport(ontology, modifiedDeclaration));
+            }
+
+            OWLDocumentFormat format = ontManager.getOntologyFormat(ontology);
+
+            if (format != null && format.isPrefixOWLOntologyFormat()) {
+                PrefixDocumentFormat pdf = format.asPrefixOWLOntologyFormat();
+                Map<String, String> map = pdf.getPrefixName2PrefixMap();
+                map.forEach((p, iri) -> logger.info("original {} = {}", p, iri));
+                for (Map.Entry<String,String> entry : map.entrySet()){
+                    pdf.setPrefix(entry.getKey(), urlConverter(entry.getValue()).toExternalForm());
+                }
+                map.forEach((p, iri) -> logger.info("corrected {} = {}", p, iri));
+            } else {
+                logger.info("Ontology format has no prefixes to be redirected.");
+            }
+
+            return ontology;
+        } catch (OWLOntologyCreationException e) {
+            // Handle exceptions like file not found or parsing errors
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public static URL urlConverter(String url) throws IOException {
+        HttpURLConnection con =
+                (HttpURLConnection) new URL(url).openConnection();
+        con.setInstanceFollowRedirects(true);
+        con.setRequestMethod("HEAD");
+
+        while (con.getHeaderField("Location") != null) {
+            con = (HttpURLConnection) new URL(con.getHeaderField("Location")).openConnection();
+            con.setInstanceFollowRedirects(true);
+            con.setRequestMethod("HEAD");
+        }
+        logger.info("url: {}", con.getURL().toExternalForm());
+        return con.getURL();
     }
 
     private FileOutputStream getFileOutPutStreamForExecutionPath(String outputFile) {

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/OntologyConversion.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/OntologyConversion.java
@@ -155,10 +155,10 @@ public class OntologyConversion {
             }
 
             OWLDataFactory df = ontManager.getOWLDataFactory();
+            logger.info("imports being updated: ");
             for (OWLImportsDeclaration declaration : ontology.getImportsDeclarations()){
                 IRI modifiedIri = IRI.create(urlConverter(declaration.getIRI().toString()));
                 OWLImportsDeclaration modifiedDeclaration = df.getOWLImportsDeclaration(modifiedIri);
-                logger.info("original imports iri {} being replaced with {}", declaration.getIRI(), modifiedIri);
                 ontManager.applyChange(new RemoveImport(ontology, declaration));
                 ontManager.applyChange(new AddImport(ontology, modifiedDeclaration));
             }
@@ -168,11 +168,10 @@ public class OntologyConversion {
             if (format != null && format.isPrefixOWLOntologyFormat()) {
                 PrefixDocumentFormat pdf = format.asPrefixOWLOntologyFormat();
                 Map<String, String> map = pdf.getPrefixName2PrefixMap();
-                map.forEach((p, iri) -> logger.info("original {} = {}", p, iri));
+                logger.info("prefixes being updated: ");
                 for (Map.Entry<String,String> entry : map.entrySet()){
                     pdf.setPrefix(entry.getKey(), urlConverter(entry.getValue()).toExternalForm());
                 }
-                map.forEach((p, iri) -> logger.info("corrected {} = {}", p, iri));
             } else {
                 logger.info("Ontology format has no prefixes to be redirected.");
             }
@@ -185,8 +184,13 @@ public class OntologyConversion {
     }
 
     public static URL urlConverter(String url) throws IOException {
-        HttpURLConnection con =
-                (HttpURLConnection) new URL(url).openConnection();
+        if (url.startsWith("file:")) {
+            URL fbURL = new URL(url);
+            logger.info("file based url: {}", fbURL.toExternalForm());
+            return fbURL;
+        }
+        HttpURLConnection con = (HttpURLConnection) new URL(url).openConnection();
+        logger.info("original url: {}", con.getURL().toExternalForm());
         con.setInstanceFollowRedirects(true);
         con.setRequestMethod("HEAD");
 

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/OntologyConversion.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/OntologyConversion.java
@@ -154,12 +154,11 @@ public class OntologyConversion {
                 }
             }
 
-            // The loaded ontology will contain the import declarations
             OWLDataFactory df = ontManager.getOWLDataFactory();
             for (OWLImportsDeclaration declaration : ontology.getImportsDeclarations()){
                 IRI modifiedIri = IRI.create(urlConverter(declaration.getIRI().toString()));
                 OWLImportsDeclaration modifiedDeclaration = df.getOWLImportsDeclaration(modifiedIri);
-                logger.info("original iri {} being replaced with {}", declaration.getIRI(), modifiedIri);
+                logger.info("original imports iri {} being replaced with {}", declaration.getIRI(), modifiedIri);
                 ontManager.applyChange(new RemoveImport(ontology, declaration));
                 ontManager.applyChange(new AddImport(ontology, modifiedDeclaration));
             }
@@ -180,7 +179,6 @@ public class OntologyConversion {
 
             return ontology;
         } catch (OWLOntologyCreationException e) {
-            // Handle exceptions like file not found or parsing errors
             e.printStackTrace();
         }
         return null;
@@ -197,7 +195,7 @@ public class OntologyConversion {
             con.setInstanceFollowRedirects(true);
             con.setRequestMethod("HEAD");
         }
-        logger.info("url: {}", con.getURL().toExternalForm());
+        logger.info("redirected url: {}", con.getURL().toExternalForm());
         return con.getURL();
     }
 


### PR DESCRIPTION
Fixes #141 
- Handled Ontology Conversion failure due to Non UTF Characters.
- Handled Ontology Conversion failure due to prefixes or imports that require to be redirected by updating them with their redirected versions.